### PR TITLE
Add: helper to keep strong references to created tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ See `examples/` folder for example use, or look into OpenTTD repositories contai
 
 # Modules
 
+## asyncio_helper
+
+Helpers to make the user of `ayncio` easier.
+
+- task: `enable_strong_referenced_tasks()` makes returned tasks from `ayncio.create_task` strong, so they are not garbage collected unexpectedly.
+
 ## click_helper
 
-Helpers to make the use of "click" easier.
+Helpers to make the use of `click` easier.
 
 - command: by default, add `-h` to the allowed parameters.
 - extend: allow extending a `click.command()` in other functions.

--- a/examples/asyncio_helper.py
+++ b/examples/asyncio_helper.py
@@ -1,0 +1,17 @@
+import asyncio
+
+from openttd_helpers import asyncio_helper
+
+
+def main():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    asyncio_helper.enable_strong_referenced_tasks(loop)
+
+    loop.create_task(asyncio.sleep(1))
+    loop.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/openttd_helpers/asyncio_helper/__init__.py
+++ b/openttd_helpers/asyncio_helper/__init__.py
@@ -1,0 +1,1 @@
+from .task import enable_strong_referenced_tasks  # noqa

--- a/openttd_helpers/asyncio_helper/task.py
+++ b/openttd_helpers/asyncio_helper/task.py
@@ -1,0 +1,36 @@
+import asyncio
+
+
+TASKS = set()
+
+
+def _create_task_factory(parent_factory):
+    def task_factory_impl(loop, coro):
+        if parent_factory is None:
+            task = asyncio.tasks.Task(coro, loop=loop)
+        else:
+            task = parent_factory(loop, coro)
+
+        task.add_done_callback(TASKS.discard)
+        TASKS.add(task)
+
+        return task
+
+    return task_factory_impl
+
+
+def enable_strong_referenced_tasks(loop=None):
+    """
+    Ensures that all tasks created have a strong reference, so the GC doesn't
+    clean them up unexpectedly.
+
+    This is a design choice of asyncio; just one that is rather annoying to
+    deal with.
+    """
+
+    if loop is None:
+        loop = asyncio.get_event_loop()
+
+    task_factory = loop.get_task_factory()
+    new_task_factory = _create_task_factory(task_factory)
+    loop.set_task_factory(new_task_factory)

--- a/regression/asyncio.yaml
+++ b/regression/asyncio.yaml
@@ -1,0 +1,1 @@
+execute: examples/asyncio_helper.py


### PR DESCRIPTION
Python's asyncio.create_task() keeps an internal weak reference. In result, the GC can remove the task if the returning task is not tracked.

But it is much more convenient to use that function as a fire&forget, and to not always have to track it.

So, instead of having to add code in other places to send these tasks to a background-queue, take over the whole factory and create a strong reference for every task created.