### PR TITLE
Fix: Sentry emit an (empty) report every minute

### DIFF
--- a/openttd_helpers/sentry_helper/click_sentry.py
+++ b/openttd_helpers/sentry_helper/click_sentry.py
@@ -31,7 +31,7 @@ def click_sentry(sentry_dsn, sentry_environment):
     with open(".version") as f:
         release = f.readline().strip()
 
-    sentry_sdk.init(sentry_dsn, release=release, environment=sentry_environment)
+    sentry_sdk.init(sentry_dsn, release=release, environment=sentry_environment, send_client_reports=False)
     log.info(
         "Sentry initialized with release='%s' and environment='%s'",
         release,


### PR DESCRIPTION
While working on the new infrastructure, I noticed that every minute all services send a report to Sentry. After some investigation, turns out that this is the "client report".

I have a bit of an issues with this reporting. This client report contains how many events were missed, for statistical goals. Which on its own is fine. But .. it also sends this report even if there are no missed events at all. And it sends this every minute.

So this really smells like tracking, more than something that is actually useful. I am sure it was added with the best intentions, but having all services that use Sentry report in every minute with an empty report feels ... very ... wrong? bad? silly? useless?

Anyway, enough ranting. Let's just disable the ~~tracking~~ reporting, and be done with it.