### PR TITLE
Fix: Sentry reports every minute how many sessions it has seen

### DIFF
--- a/openttd_helpers/sentry_helper/click_sentry.py
+++ b/openttd_helpers/sentry_helper/click_sentry.py
@@ -31,7 +31,13 @@ def click_sentry(sentry_dsn, sentry_environment):
     with open(".version") as f:
         release = f.readline().strip()
 
-    sentry_sdk.init(sentry_dsn, release=release, environment=sentry_environment, send_client_reports=False)
+    sentry_sdk.init(
+        sentry_dsn,
+        release=release,
+        environment=sentry_environment,
+        send_client_reports=False,
+        auto_session_tracking=False,
+    )
     log.info(
         "Sentry initialized with release='%s' and environment='%s'",
         release,


### PR DESCRIPTION
Similar to `send_client_reports`, this sends a report every minute about activity. And all that for seeing a percentage of crashes sessions on a dashboard.

That really is not worth it .. not in balance of bandwidth, but also not in the balance of privacy. Disable auto tracking of sessions.

PS: if the 60 seconds was configurable, it would have been nice .. like once an hour is more than sufficient enough to report this information.