### PR TITLE
Fix: replace OpenTTD/actions/checkout action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
-
-    - name: Checkout tags
-      uses: openttd/actions/checkout@v5
-      with:
-        with-tags: true
+        fetch-tags: true
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
It was removed a long time ago. actions/checkout now support fetching tags.